### PR TITLE
enable saving embeddings in chunks and max shape

### DIFF
--- a/torchbiggraph/checkpoint_storage.py
+++ b/torchbiggraph/checkpoint_storage.py
@@ -154,7 +154,8 @@ OPTIMIZER_STATE_DICT_DATASET = "optimizer/state_dict"
 
 
 def save_embeddings(hf: h5py.File, embeddings: FloatTensorType) -> None:
-    hf.create_dataset(EMBEDDING_DATASET, data=embeddings.numpy())
+    data = embeddings.numpy()
+    hf.create_dataset(EMBEDDING_DATASET, data=data, chunks=True, maxshape=(None, data.shape[1]))
 
 
 def load_embeddings(


### PR DESCRIPTION
For incremental retraining, we need to save with chunks enabled and also enabled a max shape of (infinite, embedding_dimensions)
Axes with None are unlimited.